### PR TITLE
chore(medlemskap): migrate from GET /api/v1/medlemskapsunntak to POST /rest/v1/periode/soek

### DIFF
--- a/src/test/kotlin/no/nav/pensjon/opptjening/omsorgsopptjening/bestem/pensjonsopptjening/common/SpringContextTest.kt
+++ b/src/test/kotlin/no/nav/pensjon/opptjening/omsorgsopptjening/bestem/pensjonsopptjening/common/SpringContextTest.kt
@@ -47,7 +47,7 @@ sealed class SpringContextTest {
         const val OPPGAVE_PATH = "/api/v1/oppgaver"
         const val POPP_OMSORG_PATH = "/api/omsorg"
         const val POPP_PENSJONSPOENG_PATH = "/api/pensjonspoeng"
-        const val MEDLEMSKAP_PATH = "/api/v1/medlemskapsunntak"
+        const val MEDLEMSKAP_PATH = "/rest/v1/periode/soek"
         const val PEN_ALDERVEDTAK_PATH = "/pen/api/alderspensjon/vedtak/gjeldende"
         const val PEN_UFOREVEDTAK_PATH = "/pen/api/uforetrygd/vedtak/gjeldende"
     }
@@ -147,7 +147,7 @@ sealed class SpringContextTest {
             producer.send(pr).get()
         }
 
-        fun send(melding: String){
+        fun send(melding: String) {
             val pr = ProducerRecord(
                 Topics.Omsorgsopptjening.NAME,
                 null,

--- a/src/test/kotlin/no/nav/pensjon/opptjening/omsorgsopptjening/bestem/pensjonsopptjening/common/WiremockUtils.kt
+++ b/src/test/kotlin/no/nav/pensjon/opptjening/omsorgsopptjening/bestem/pensjonsopptjening/common/WiremockUtils.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.common.FileSource
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
@@ -88,7 +87,7 @@ fun WireMockExtension.stubForPdlTransformer() {
 
 fun WireMockExtension.ingenUnntaksperioderForMedlemskap() {
     this.stubFor(
-        WireMock.get(WireMock.urlPathEqualTo(SpringContextTest.MEDLEMSKAP_PATH))
+        WireMock.post(WireMock.urlPathEqualTo(SpringContextTest.MEDLEMSKAP_PATH))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
@@ -103,8 +102,7 @@ fun WireMockExtension.unntaksperioderUtenMedlemskap(
     perioder: Set<Periode>
 ) {
     this.stubFor(
-        WireMock.get(WireMock.urlPathEqualTo(SpringContextTest.MEDLEMSKAP_PATH))
-            .withHeader("Nav-Personident", equalTo(fnr))
+        WireMock.post(WireMock.urlPathEqualTo(SpringContextTest.MEDLEMSKAP_PATH))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
@@ -155,8 +153,7 @@ fun WireMockExtension.unntaksperioderMedPliktigEllerFrivilligMedlemskap(
     perioder: Set<Periode>
 ) {
     this.stubFor(
-        WireMock.get(WireMock.urlPathEqualTo(SpringContextTest.MEDLEMSKAP_PATH))
-            .withHeader("Nav-Personident", equalTo(fnr))
+        WireMock.post(WireMock.urlPathEqualTo(SpringContextTest.MEDLEMSKAP_PATH))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)


### PR DESCRIPTION
[Notice from MEDL-owners](https://nav-it.slack.com/archives/CLZ9RS7H8/p1741677265015469) that passing Nav-Personident is not valid privacy pattern. Therefore GET /api/v1/medlemskapsunntak is depricated. Now using new endpoint POST /rest/v1/periode/soek, passing personident in request body